### PR TITLE
Update and pin GitHub Actions

### DIFF
--- a/.github/workflows/msdevopssec.yml
+++ b/.github/workflows/msdevopssec.yml
@@ -21,11 +21,11 @@ jobs:
     steps:
 
       # Checkout your code repository to scan
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       # Run analyzers
     - name: Run Microsoft Security DevOps
-      uses: microsoft/security-devops-action@latest
+      uses: microsoft/security-devops-action@d0736c546281e0632667b8e0046ae3d7bba0bf67
       id: msdo
     # with:
       # config: string. Optional. A file path to an MSDO configuration file ('*.gdnconfig').


### PR DESCRIPTION
## Summary

- Update GitHub Actions to the current verified release commits.
- Pin every external action reference in the affected workflow files to an immutable commit SHA.
- Preserve local action references.

## Why

This keeps workflow execution reproducible and applies the approved action-runtime and security updates. This PR does not change application code, permissions, triggers, secrets, deployments, or release behavior.

## Validation

- git diff --check passed locally.
- Workflow checks should run on this PR where the repository has pull-request triggers.
- Release, signing, live-smoke, and deployment workflows were not dispatched automatically.

## Commit

264eae420b0666ae7c4f2433dee286fd23a12cd3
